### PR TITLE
[IMP] bi_birthday_reminder: remove year from email

### DIFF
--- a/bi_birthday_reminder/data/birthday_reminder_action_data.xml
+++ b/bi_birthday_reminder/data/birthday_reminder_action_data.xml
@@ -66,7 +66,7 @@
                                             <t t-out="customer['name']" />
                                         </td>
                                         <td>
-                                            <t t-out="customer['birthdate']" />
+                                            <t t-out="(customer['birthdate']).strftime('%d %B')" />
                                         </td>
                                     </tr>
                                 </t>


### PR DESCRIPTION
When emails notifying of upcoming birthdays are sent, the birthday goes with the day, month and year. What we want is to only have the day and month in the date. This update ensures that. 